### PR TITLE
fix: 评论后，评论框的内容完整清空的bug

### DIFF
--- a/src/client/view/submit.svelte
+++ b/src/client/view/submit.svelte
@@ -243,6 +243,7 @@
       if (result.data instanceof Array) {
         dispatch('submitComment', { data: result.data, pid })
         metas.content.value = ''
+        SaveInfo()
         isPreview = false
       }
     } catch (error) {


### PR DESCRIPTION
评论后，评论框的内容清空了，但 localStorage 并未清空，导致下次访问页面的时候依然显示上一次的评论内容