### PR TITLE
fix: cannot find pg package in vercel, and pg connection is insecure

### DIFF
--- a/src/server/database/storage/postgresql.js
+++ b/src/server/database/storage/postgresql.js
@@ -2,7 +2,7 @@ const { D_PG_URL } = process.env
 
 process.env.D_SEQUELIZE_DB = JSON.stringify([D_PG_URL])
 
-let sequelizeConfig = {
+const sequelizeConfig = {
   dialectModule: require('pg'),
   dialectOptions: {
     ssl: true

--- a/src/server/database/storage/postgresql.js
+++ b/src/server/database/storage/postgresql.js
@@ -2,4 +2,11 @@ const { D_PG_URL } = process.env
 
 process.env.D_SEQUELIZE_DB = JSON.stringify([D_PG_URL])
 
-module.exports = async () => require('./sequelize')()
+let sequelizeConfig = {
+  dialectModule: require('pg'),
+  dialectOptions: {
+    ssl: true
+  }
+}
+
+module.exports = async () => require('./sequelize')(sequelizeConfig)

--- a/src/server/database/storage/sequelize.js
+++ b/src/server/database/storage/sequelize.js
@@ -7,8 +7,6 @@ const {
   DISCUSS_DB_COUNTER = 'd_counter'
 } = process.env
 
-const sequelize = new Sequelize(JSON.parse(D_SEQUELIZE_DB)[0])
-
 const ModelOptions = { freezeTableName: true, timestamps: false }
 
 const AdminModel = {
@@ -124,7 +122,6 @@ const AdminModel = {
     allowNull: false
   }
 }
-const Admin = sequelize.define(DISCUSS_DB_ADMIN, AdminModel, ModelOptions)
 
 const CommentModel = {
   id: {
@@ -199,7 +196,6 @@ const CommentModel = {
     allowNull: false
   }
 }
-const Comment = sequelize.define(DISCUSS_DB_COMMENT, CommentModel, ModelOptions)
 
 const CounterModel = {
   id: {
@@ -226,7 +222,6 @@ const CounterModel = {
     allowNull: false
   }
 }
-const Counter = sequelize.define(DISCUSS_DB_COUNTER, CounterModel, ModelOptions)
 
 function findAllHandler(datas) {
   const result = []
@@ -234,8 +229,15 @@ function findAllHandler(datas) {
   return result
 }
 
-module.exports = async () => {
+module.exports = async (sequelizeConfig = {}) => {
+  const sequelize = new Sequelize(JSON.parse(D_SEQUELIZE_DB)[0], sequelizeConfig)
+
+  const Admin = sequelize.define(DISCUSS_DB_ADMIN, AdminModel, ModelOptions)
+  const Comment = sequelize.define(DISCUSS_DB_COMMENT, CommentModel, ModelOptions)
+  const Counter = sequelize.define(DISCUSS_DB_COUNTER, CounterModel, ModelOptions)
+
   await sequelize.sync()
+
   return {
     async addAdmin(data) {
       await Admin.create(data)


### PR DESCRIPTION
1. 部署到vercel并使用vercel提供的pg，访问链接会报错，vercel log显示 
```
🐞` [35m/var/task/___vc/__launcher.js[39m[90m:[39m[32m3247[39m
Error: Please install pg package manually
```
解决方案: 手动传入 ` require('pg') `
[Error: Please install pg package manually](https://github.com/orgs/vercel/discussions/234)

2. 使用 sequelize 访问vercel的pg会报错：
```
ConnectionError [SequelizeConnectionError]: connection is insecure (try using `sslmode=require`)
```
解决方案: 添加 `ssl: true`
[Can't use SSL with Postgres](https://github.com/sequelize/sequelize/issues/956#issuecomment-147745033) 